### PR TITLE
🚀 Android 정시 알림 및 새로고침 UX 안정화

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -45,6 +45,7 @@ kotlin {
                 implementation(libs.kotlinx.coroutines.test)
                 implementation(libs.androidx.testExt.junit)
                 implementation(libs.androidx.test.runner)
+                implementation("androidx.compose.ui:ui-test-junit4-android:1.9.4")
             }
         }
         val iosX64Main by getting
@@ -205,4 +206,5 @@ android {
 
 dependencies {
     debugImplementation(compose.uiTooling)
+    debugImplementation("androidx.compose.ui:ui-test-manifest:1.9.4")
 }

--- a/composeApp/src/androidInstrumentedTest/kotlin/net/ifmain/hwanultoktok/kmp/alarm/ExchangeRateAlarmSchedulerDeviceTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/net/ifmain/hwanultoktok/kmp/alarm/ExchangeRateAlarmSchedulerDeviceTest.kt
@@ -1,0 +1,41 @@
+package net.ifmain.hwanultoktok.kmp.alarm
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.runner.RunWith
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@RunWith(AndroidJUnit4::class)
+class ExchangeRateAlarmSchedulerDeviceTest {
+
+    @Test
+    fun registersCancelsAndRestoresTheNextAlarm() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val scheduler = ExchangeRateAlarmScheduler(context)
+        val now = Instant.now()
+
+        scheduler.cancel()
+
+        try {
+            val registration = scheduler.scheduleNext(now = now)
+
+            assertTrue(registration.triggerAtMillis > now.toEpochMilli())
+            assertEquals(
+                registration.triggerAtMillis,
+                scheduler.scheduledTriggerAtMillis(),
+            )
+            assertEquals(scheduler.canScheduleExactAlarms(), registration.isExact)
+            assertTrue(scheduler.isScheduled(now))
+
+            scheduler.cancel()
+
+            assertFalse(scheduler.isScheduled(now))
+        } finally {
+            scheduler.scheduleNext()
+        }
+    }
+}

--- a/composeApp/src/androidInstrumentedTest/kotlin/net/ifmain/hwanultoktok/kmp/presentation/ui/ExchangeRateScreenDeviceTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/net/ifmain/hwanultoktok/kmp/presentation/ui/ExchangeRateScreenDeviceTest.kt
@@ -1,0 +1,47 @@
+package net.ifmain.hwanultoktok.kmp.presentation.ui
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasProgressBarRangeInfo
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import net.ifmain.hwanultoktok.kmp.presentation.state.ExchangeRateUiState
+import org.junit.Rule
+import org.junit.runner.RunWith
+import kotlin.test.Test
+
+@RunWith(AndroidJUnit4::class)
+class ExchangeRateScreenDeviceTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun refreshingStateShowsBlockingStatusAndDisablesRefresh() {
+        composeTestRule.setContent {
+            MaterialTheme {
+                ExchangeRateScreen(
+                    uiState = ExchangeRateUiState(isRefreshing = true),
+                    onRefreshClick = {},
+                    onClearErrorClick = {},
+                    onToggleFavoritesFilter = {},
+                    onFavoriteClick = {},
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithText("최신 환율로 새로고침 중이에요")
+            .assertIsDisplayed()
+        composeTestRule
+            .onNode(hasProgressBarRangeInfo(ProgressBarRangeInfo.Indeterminate))
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithContentDescription("새로고침")
+            .assertIsNotEnabled()
+    }
+}

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -4,7 +4,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
     <application
         android:name=".HwanulTokTokApplication"
@@ -24,6 +25,24 @@
             <meta-data
                 android:name="android.appwidget.provider"
                 android:resource="@xml/favorite_exchange_rate_widget_info" />
+        </receiver>
+
+        <receiver
+            android:name=".alarm.ExchangeRateAlarmReceiver"
+            android:exported="false" />
+
+        <receiver
+            android:name=".alarm.ExchangeRateAlarmRescheduleReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.DATE_CHANGED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+                <action android:name="android.intent.action.TIME_SET" />
+                <action android:name="android.intent.action.TIMEZONE_CHANGED" />
+                <action android:name="android.app.action.SCHEDULE_EXACT_ALARM_PERMISSION_STATE_CHANGED" />
+            </intent-filter>
         </receiver>
         
         <!-- AdMob App ID -->

--- a/composeApp/src/androidMain/kotlin/net/ifmain/hwanultoktok/kmp/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/net/ifmain/hwanultoktok/kmp/MainActivity.kt
@@ -4,29 +4,29 @@ import android.Manifest
 import android.app.Application
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.google.android.gms.ads.MobileAds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import net.ifmain.hwanultoktok.kmp.alarm.ExchangeRateAlarmScheduler
 import net.ifmain.hwanultoktok.kmp.di.commonModule
 import net.ifmain.hwanultoktok.kmp.di.platformModule
-import net.ifmain.hwanultoktok.kmp.domain.usecase.ScheduleExchangeRateCheckUseCase
 import net.ifmain.hwanultoktok.kmp.presentation.AppWithBottomAd
 import org.koin.android.ext.koin.androidContext
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 import org.koin.core.context.startKoin
 
-class HwanulTokTokApplication : Application(), KoinComponent {
+class HwanulTokTokApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         startKoin {
@@ -34,14 +34,22 @@ class HwanulTokTokApplication : Application(), KoinComponent {
             modules(commonModule, platformModule)
         }
 
-        CoroutineScope(Dispatchers.IO).launch {
-            val scheduleUseCase: ScheduleExchangeRateCheckUseCase by inject()
-             scheduleUseCase(11, 30)
-        }
+        ExchangeRateAlarmScheduler(this).ensureScheduled()
     }
 }
 
 class MainActivity : ComponentActivity() {
+    private val notificationPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) {
+        maybeShowExactAlarmPermissionRationale()
+    }
+    private val exactAlarmPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+    ) {
+        ExchangeRateAlarmScheduler(this).scheduleNext()
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
@@ -51,21 +59,6 @@ class MainActivity : ComponentActivity() {
             MobileAds.initialize(this@MainActivity) {}
         }
         
-        // Android 13+ 알림 권한 요청
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            if (ContextCompat.checkSelfPermission(
-                    this,
-                    Manifest.permission.POST_NOTIFICATIONS
-                ) != PackageManager.PERMISSION_GRANTED
-            ) {
-                ActivityCompat.requestPermissions(
-                    this,
-                    arrayOf(Manifest.permission.POST_NOTIFICATIONS),
-                    1
-                )
-            }
-        }
-
         try {
             setContent {
                 AppWithAds()
@@ -76,6 +69,60 @@ class MainActivity : ComponentActivity() {
             finish()
             startActivity(Intent(this, MainActivity::class.java))
         }
+
+        requestNotificationAndExactAlarmAccess()
+    }
+
+    private fun requestNotificationAndExactAlarmAccess() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        } else {
+            maybeShowExactAlarmPermissionRationale()
+        }
+    }
+
+    private fun maybeShowExactAlarmPermissionRationale() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return
+
+        val alarmScheduler = ExchangeRateAlarmScheduler(this)
+        val preferences = getSharedPreferences(PERMISSION_PREFERENCES, MODE_PRIVATE)
+        if (alarmScheduler.canScheduleExactAlarms() ||
+            preferences.getBoolean(KEY_EXACT_ALARM_RATIONALE_SHOWN, false)
+        ) {
+            return
+        }
+
+        preferences.edit()
+            .putBoolean(KEY_EXACT_ALARM_RATIONALE_SHOWN, true)
+            .apply()
+
+        android.app.AlertDialog.Builder(this)
+            .setTitle("정확한 환율 알림 설정")
+            .setMessage(
+                "평일 오전 11시 30분에 환율을 확인하려면 " +
+                    "'알람 및 리마인더' 권한이 필요합니다. " +
+                    "허용하지 않아도 알림은 예약되지만 지연될 수 있습니다.",
+            )
+            .setPositiveButton("설정하기") { _, _ ->
+                exactAlarmPermissionLauncher.launch(
+                    Intent(
+                        Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM,
+                        Uri.parse("package:$packageName"),
+                    ),
+                )
+            }
+            .setNegativeButton("나중에", null)
+            .show()
+    }
+
+    private companion object {
+        const val PERMISSION_PREFERENCES = "notification_permission_guidance"
+        const val KEY_EXACT_ALARM_RATIONALE_SHOWN = "exact_alarm_rationale_shown"
     }
 }
 

--- a/composeApp/src/androidMain/kotlin/net/ifmain/hwanultoktok/kmp/alarm/ExchangeRateAlarmReceiver.kt
+++ b/composeApp/src/androidMain/kotlin/net/ifmain/hwanultoktok/kmp/alarm/ExchangeRateAlarmReceiver.kt
@@ -1,0 +1,40 @@
+package net.ifmain.hwanultoktok.kmp.alarm
+
+import android.app.AlarmManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class ExchangeRateAlarmReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val hour = intent.getIntExtra(
+            EXTRA_HOUR,
+            DEFAULT_EXCHANGE_RATE_CHECK_HOUR,
+        )
+        val minute = intent.getIntExtra(
+            EXTRA_MINUTE,
+            DEFAULT_EXCHANGE_RATE_CHECK_MINUTE,
+        )
+
+        ExchangeRateAlarmScheduler(context).scheduleNext(hour, minute)
+        ExchangeRateWorkScheduler.enqueue(context)
+    }
+}
+
+class ExchangeRateAlarmRescheduleReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        when (intent.action) {
+            Intent.ACTION_BOOT_COMPLETED,
+            Intent.ACTION_DATE_CHANGED,
+            Intent.ACTION_MY_PACKAGE_REPLACED,
+            Intent.ACTION_TIME_CHANGED,
+            Intent.ACTION_TIMEZONE_CHANGED,
+            AlarmManager.ACTION_SCHEDULE_EXACT_ALARM_PERMISSION_STATE_CHANGED,
+            -> Unit
+
+            else -> return
+        }
+
+        ExchangeRateAlarmScheduler(context).scheduleNext()
+    }
+}

--- a/composeApp/src/androidMain/kotlin/net/ifmain/hwanultoktok/kmp/alarm/ExchangeRateAlarmSchedule.kt
+++ b/composeApp/src/androidMain/kotlin/net/ifmain/hwanultoktok/kmp/alarm/ExchangeRateAlarmSchedule.kt
@@ -1,0 +1,36 @@
+package net.ifmain.hwanultoktok.kmp.alarm
+
+import java.time.DayOfWeek
+import java.time.Instant
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+internal object ExchangeRateAlarmSchedule {
+    private val koreaZone: ZoneId = ZoneId.of("Asia/Seoul")
+
+    fun nextWeekdayTrigger(
+        now: Instant,
+        hour: Int,
+        minute: Int,
+    ): Instant {
+        val targetTime = LocalTime.of(hour, minute)
+        var candidate = ZonedDateTime.of(
+            now.atZone(koreaZone).toLocalDate(),
+            targetTime,
+            koreaZone,
+        )
+
+        if (!candidate.toInstant().isAfter(now)) {
+            candidate = candidate.plusDays(1)
+        }
+
+        while (candidate.dayOfWeek == DayOfWeek.SATURDAY ||
+            candidate.dayOfWeek == DayOfWeek.SUNDAY
+        ) {
+            candidate = candidate.plusDays(1)
+        }
+
+        return candidate.toInstant()
+    }
+}

--- a/composeApp/src/androidMain/kotlin/net/ifmain/hwanultoktok/kmp/alarm/ExchangeRateAlarmScheduler.kt
+++ b/composeApp/src/androidMain/kotlin/net/ifmain/hwanultoktok/kmp/alarm/ExchangeRateAlarmScheduler.kt
@@ -1,0 +1,157 @@
+package net.ifmain.hwanultoktok.kmp.alarm
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import java.time.Instant
+
+internal const val DEFAULT_EXCHANGE_RATE_CHECK_HOUR = 11
+internal const val DEFAULT_EXCHANGE_RATE_CHECK_MINUTE = 30
+
+internal data class ExchangeRateAlarmRegistration(
+    val triggerAtMillis: Long,
+    val isExact: Boolean,
+)
+
+internal class ExchangeRateAlarmScheduler(
+    context: Context,
+) {
+    private val applicationContext = context.applicationContext
+    private val alarmManager = applicationContext.getSystemService(AlarmManager::class.java)
+    private val preferences = applicationContext.getSharedPreferences(
+        PREFERENCES_NAME,
+        Context.MODE_PRIVATE,
+    )
+
+    fun ensureScheduled(
+        hour: Int = DEFAULT_EXCHANGE_RATE_CHECK_HOUR,
+        minute: Int = DEFAULT_EXCHANGE_RATE_CHECK_MINUTE,
+        now: Instant = Instant.now(),
+    ): ExchangeRateAlarmRegistration {
+        val storedTriggerAtMillis = preferences.getLong(KEY_TRIGGER_AT_MILLIS, 0L)
+        val storedAsExact = preferences.getBoolean(KEY_IS_EXACT, false)
+        val storedHour = preferences.getInt(KEY_HOUR, -1)
+        val storedMinute = preferences.getInt(KEY_MINUTE, -1)
+        val exactAlarmAvailable = canScheduleExactAlarms()
+        val hasCurrentPendingIntent = existingPendingIntent() != null
+
+        if (storedTriggerAtMillis > now.toEpochMilli() &&
+            storedAsExact == exactAlarmAvailable &&
+            storedHour == hour &&
+            storedMinute == minute &&
+            hasCurrentPendingIntent
+        ) {
+            return ExchangeRateAlarmRegistration(
+                triggerAtMillis = storedTriggerAtMillis,
+                isExact = storedAsExact,
+            )
+        }
+
+        return scheduleNext(hour, minute, now)
+    }
+
+    fun scheduleNext(
+        hour: Int = DEFAULT_EXCHANGE_RATE_CHECK_HOUR,
+        minute: Int = DEFAULT_EXCHANGE_RATE_CHECK_MINUTE,
+        now: Instant = Instant.now(),
+    ): ExchangeRateAlarmRegistration {
+        val triggerAtMillis = ExchangeRateAlarmSchedule.nextWeekdayTrigger(
+            now = now,
+            hour = hour,
+            minute = minute,
+        ).toEpochMilli()
+        val pendingIntent = alarmPendingIntent(hour, minute)
+        val scheduledExactly = scheduleAlarm(triggerAtMillis, pendingIntent)
+
+        preferences.edit()
+            .putLong(KEY_TRIGGER_AT_MILLIS, triggerAtMillis)
+            .putBoolean(KEY_IS_EXACT, scheduledExactly)
+            .putInt(KEY_HOUR, hour)
+            .putInt(KEY_MINUTE, minute)
+            .apply()
+
+        return ExchangeRateAlarmRegistration(
+            triggerAtMillis = triggerAtMillis,
+            isExact = scheduledExactly,
+        )
+    }
+
+    fun cancel() {
+        existingPendingIntent()?.let { pendingIntent ->
+            alarmManager.cancel(pendingIntent)
+            pendingIntent.cancel()
+        }
+        preferences.edit().clear().apply()
+    }
+
+    fun isScheduled(now: Instant = Instant.now()): Boolean =
+        preferences.getLong(KEY_TRIGGER_AT_MILLIS, 0L) > now.toEpochMilli() &&
+            existingPendingIntent() != null
+
+    fun canScheduleExactAlarms(): Boolean =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.S ||
+            alarmManager.canScheduleExactAlarms()
+
+    internal fun scheduledTriggerAtMillis(): Long =
+        preferences.getLong(KEY_TRIGGER_AT_MILLIS, 0L)
+
+    private fun scheduleAlarm(
+        triggerAtMillis: Long,
+        pendingIntent: PendingIntent,
+    ): Boolean {
+        if (canScheduleExactAlarms()) {
+            try {
+                alarmManager.setExactAndAllowWhileIdle(
+                    AlarmManager.RTC_WAKEUP,
+                    triggerAtMillis,
+                    pendingIntent,
+                )
+                return true
+            } catch (_: SecurityException) {
+                // 권한이 확인 직후 철회된 경우 아래의 일반 알람으로 대체한다.
+            }
+        }
+
+        alarmManager.setAndAllowWhileIdle(
+            AlarmManager.RTC_WAKEUP,
+            triggerAtMillis,
+            pendingIntent,
+        )
+        return false
+    }
+
+    private fun alarmPendingIntent(hour: Int, minute: Int): PendingIntent {
+        val intent = Intent(applicationContext, ExchangeRateAlarmReceiver::class.java)
+            .putExtra(EXTRA_HOUR, hour)
+            .putExtra(EXTRA_MINUTE, minute)
+
+        return PendingIntent.getBroadcast(
+            applicationContext,
+            ALARM_REQUEST_CODE,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    private fun existingPendingIntent(): PendingIntent? =
+        PendingIntent.getBroadcast(
+            applicationContext,
+            ALARM_REQUEST_CODE,
+            Intent(applicationContext, ExchangeRateAlarmReceiver::class.java),
+            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+    private companion object {
+        const val PREFERENCES_NAME = "exchange_rate_alarm"
+        const val KEY_TRIGGER_AT_MILLIS = "trigger_at_millis"
+        const val KEY_IS_EXACT = "is_exact"
+        const val KEY_HOUR = "hour"
+        const val KEY_MINUTE = "minute"
+        const val ALARM_REQUEST_CODE = 11_30
+    }
+}
+
+internal const val EXTRA_HOUR = "exchange_rate_alarm_hour"
+internal const val EXTRA_MINUTE = "exchange_rate_alarm_minute"

--- a/composeApp/src/androidMain/kotlin/net/ifmain/hwanultoktok/kmp/alarm/ExchangeRateWorkScheduler.kt
+++ b/composeApp/src/androidMain/kotlin/net/ifmain/hwanultoktok/kmp/alarm/ExchangeRateWorkScheduler.kt
@@ -1,0 +1,30 @@
+package net.ifmain.hwanultoktok.kmp.alarm
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import net.ifmain.hwanultoktok.kmp.worker.ExchangeRateWorker
+
+internal object ExchangeRateWorkScheduler {
+    const val WORK_NAME = "exchange_rate_check"
+    const val WORK_TAG = "exchange_rate_check"
+
+    fun enqueue(context: Context) {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+        val workRequest = OneTimeWorkRequestBuilder<ExchangeRateWorker>()
+            .setConstraints(constraints)
+            .addTag(WORK_TAG)
+            .build()
+
+        WorkManager.getInstance(context.applicationContext).enqueueUniqueWork(
+            WORK_NAME,
+            ExistingWorkPolicy.REPLACE,
+            workRequest,
+        )
+    }
+}

--- a/composeApp/src/androidMain/kotlin/net/ifmain/hwanultoktok/kmp/data/repository/AndroidBackgroundTaskRepository.kt
+++ b/composeApp/src/androidMain/kotlin/net/ifmain/hwanultoktok/kmp/data/repository/AndroidBackgroundTaskRepository.kt
@@ -1,75 +1,29 @@
 package net.ifmain.hwanultoktok.kmp.data.repository
 
 import android.content.Context
-import androidx.work.*
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import net.ifmain.hwanultoktok.kmp.alarm.ExchangeRateAlarmScheduler
+import net.ifmain.hwanultoktok.kmp.alarm.ExchangeRateWorkScheduler
 import net.ifmain.hwanultoktok.kmp.domain.repository.BackgroundTaskRepository
-import net.ifmain.hwanultoktok.kmp.worker.ExchangeRateWorker
-import java.util.Calendar
-import java.util.concurrent.TimeUnit
 
 class AndroidBackgroundTaskRepository(
     private val context: Context
 ) : BackgroundTaskRepository {
     companion object {
-        const val EXCHANGE_RATE_WORK_TAG = "exchange_rate_check"
+        const val EXCHANGE_RATE_WORK_TAG = ExchangeRateWorkScheduler.WORK_TAG
     }
 
     override suspend fun scheduleExchangeRateCheck(hour: Int, minute: Int) {
-        println("AndroidBackgroundTaskRepository: scheduleExchangeRateCheck 호출 - hour: $hour, minute: $minute")
-        val currentTime = Calendar.getInstance()
-        val targetTime = Calendar.getInstance().apply {
-            set(Calendar.HOUR_OF_DAY, hour)
-            set(Calendar.MINUTE, minute)
-            set(Calendar.SECOND, 0)
-
-            if (before(currentTime)) {
-                add(Calendar.DAY_OF_MONTH, 1)
-            }
-        }
-
-        val initialDelay = targetTime.timeInMillis - currentTime.timeInMillis
-
-        val constraints = Constraints.Builder()
-            .setRequiredNetworkType(NetworkType.CONNECTED)
-            .build()
-
-        val workRequest = PeriodicWorkRequestBuilder<ExchangeRateWorker>(
-            1, TimeUnit.DAYS
-        )
-            .setInitialDelay(initialDelay, TimeUnit.MILLISECONDS)
-            .setConstraints(constraints)
-            .addTag(EXCHANGE_RATE_WORK_TAG)
-            .build()
-
-        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
-            EXCHANGE_RATE_WORK_TAG,
-            ExistingPeriodicWorkPolicy.REPLACE,
-            workRequest
-        )
-        println("AndroidBackgroundTaskRepository: WorkManager 작업 예약 완료 - 초기 대기 시간: ${initialDelay / 1000 / 60}분")
+        ExchangeRateAlarmScheduler(context).scheduleNext(hour, minute)
     }
 
     override suspend fun cancelExchangeRateCheck() {
-        WorkManager.getInstance(context).cancelUniqueWork(EXCHANGE_RATE_WORK_TAG)
+        ExchangeRateAlarmScheduler(context).cancel()
     }
 
-    override suspend fun isExchangeRateCheckScheduled(): Boolean = withContext(Dispatchers.IO) {
-        val workInfos = WorkManager.getInstance(context)
-            .getWorkInfosForUniqueWork(EXCHANGE_RATE_WORK_TAG)
-            .get()
-
-        workInfos.isNotEmpty() && workInfos.any { it.state == WorkInfo.State.ENQUEUED || it.state == WorkInfo.State.RUNNING }
-    }
+    override suspend fun isExchangeRateCheckScheduled(): Boolean =
+        ExchangeRateAlarmScheduler(context).isScheduled()
 
     override suspend fun executeExchangeRateCheck() {
-        println("AndroidBackgroundTaskRepository: executeExchangeRateCheck 호출")
-        val workRequest = OneTimeWorkRequestBuilder<ExchangeRateWorker>()
-            .addTag("immediate_check")
-            .build()
-        WorkManager.getInstance(context).enqueue(workRequest)
-        println("AndroidBackgroundTaskRepository: 즉시 실행 작업 예약 완료")
+        ExchangeRateWorkScheduler.enqueue(context)
     }
-
 }

--- a/composeApp/src/androidUnitTest/kotlin/net/ifmain/hwanultoktok/kmp/alarm/ExchangeRateAlarmScheduleTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/net/ifmain/hwanultoktok/kmp/alarm/ExchangeRateAlarmScheduleTest.kt
@@ -1,0 +1,80 @@
+package net.ifmain.hwanultoktok.kmp.alarm
+
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ExchangeRateAlarmScheduleTest {
+    private val koreaZone = ZoneId.of("Asia/Seoul")
+
+    @Test
+    fun before_target_time_schedules_same_weekday() {
+        val now = koreaTime(2026, 7, 20, 10, 0)
+
+        val next = ExchangeRateAlarmSchedule.nextWeekdayTrigger(
+            now = now,
+            hour = 11,
+            minute = 30,
+        )
+
+        assertEquals(koreaTime(2026, 7, 20, 11, 30), next)
+    }
+
+    @Test
+    fun at_target_time_schedules_next_weekday() {
+        val now = koreaTime(2026, 7, 20, 11, 30)
+
+        val next = ExchangeRateAlarmSchedule.nextWeekdayTrigger(
+            now = now,
+            hour = 11,
+            minute = 30,
+        )
+
+        assertEquals(koreaTime(2026, 7, 21, 11, 30), next)
+    }
+
+    @Test
+    fun after_friday_target_time_skips_weekend() {
+        val now = koreaTime(2026, 7, 31, 12, 0)
+
+        val next = ExchangeRateAlarmSchedule.nextWeekdayTrigger(
+            now = now,
+            hour = 11,
+            minute = 30,
+        )
+
+        assertEquals(koreaTime(2026, 8, 3, 11, 30), next)
+    }
+
+    @Test
+    fun weekend_schedules_next_monday() {
+        val now = koreaTime(2026, 8, 1, 10, 0)
+
+        val next = ExchangeRateAlarmSchedule.nextWeekdayTrigger(
+            now = now,
+            hour = 11,
+            minute = 30,
+        )
+
+        assertEquals(koreaTime(2026, 8, 3, 11, 30), next)
+    }
+
+    private fun koreaTime(
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int,
+        minute: Int,
+    ): Instant = ZonedDateTime.of(
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        0,
+        0,
+        koreaZone,
+    ).toInstant()
+}

--- a/composeApp/src/commonMain/kotlin/net/ifmain/hwanultoktok/kmp/presentation/state/ExchangeRateUiState.kt
+++ b/composeApp/src/commonMain/kotlin/net/ifmain/hwanultoktok/kmp/presentation/state/ExchangeRateUiState.kt
@@ -13,11 +13,15 @@ data class ExchangeRateUiState(
     ),
     val errorMessage: String? = null,
     val isRefreshing: Boolean = false,
+    val isRefreshThrottled: Boolean = false,
     val favoriteIds: Set<String> = emptySet(),
     val showFavoritesOnly: Boolean = false,
     val lastUpdateTime: LocalDateTime? = null,
     val formattedDataDate: String? = null,
 ) {
+    val canRefresh: Boolean
+        get() = !isLoading && !isRefreshing && !isRefreshThrottled
+
     val filteredExchangeRates: List<ExchangeRate>
         get() = exchangeRates.filter { rate ->
             val isInSelectedCurrencies = selectedCurrencies.contains(rate.currencyCode)

--- a/composeApp/src/commonMain/kotlin/net/ifmain/hwanultoktok/kmp/presentation/ui/ExchangeRateScreen.kt
+++ b/composeApp/src/commonMain/kotlin/net/ifmain/hwanultoktok/kmp/presentation/ui/ExchangeRateScreen.kt
@@ -1,5 +1,6 @@
 package net.ifmain.hwanultoktok.kmp.presentation.ui
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -11,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -32,10 +34,16 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import net.ifmain.hwanultoktok.kmp.presentation.state.ExchangeRateUiState
 import net.ifmain.hwanultoktok.kmp.presentation.viewmodel.ExchangeRateViewModel
 import org.koin.compose.koinInject
 
@@ -54,142 +62,221 @@ fun ExchangeRateScreen(
         viewModel.initialize()
     }
 
-    Column(
+    ExchangeRateScreen(
+        uiState = uiState,
+        onRefreshClick = viewModel::refreshExchangeRates,
+        onClearErrorClick = viewModel::clearError,
+        onToggleFavoritesFilter = viewModel::toggleFavoritesFilter,
+        onFavoriteClick = onFavoriteClick,
+        modifier = modifier,
+    )
+}
+
+@Composable
+internal fun ExchangeRateScreen(
+    uiState: ExchangeRateUiState,
+    onRefreshClick: () -> Unit,
+    onClearErrorClick: () -> Unit,
+    onToggleFavoritesFilter: () -> Unit,
+    onFavoriteClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
         modifier = modifier
             .fillMaxSize()
-            .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top))
+            .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top)),
     ) {
-        // Error handling
-        uiState.errorMessage?.let { error ->
-            Card(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer)
-            ) {
-                Column(modifier = Modifier.padding(16.dp)) {
-                    Text(
-                        text = "오류",
-                        style = MaterialTheme.typography.titleSmall,
-                        color = MaterialTheme.colorScheme.onErrorContainer
-                    )
-                    Text(
-                        text = error,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onErrorContainer,
-                        modifier = Modifier.padding(top = 4.dp)
-                    )
-                    Button(
-                        onClick = { viewModel.clearError() },
-                        modifier = Modifier.padding(top = 8.dp)
-                    ) {
-                        Text("확인")
-                    }
-                }
-            }
-        }
-
-        // Header with refresh button and favorites toggle
         Column(
-            modifier = Modifier.padding(horizontal = 16.dp)
+            modifier = Modifier.fillMaxSize(),
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Column {
-                    Text(
-                        text = "실시간 환율",
-                        style = MaterialTheme.typography.headlineSmall,
-                        fontWeight = FontWeight.Bold,
-                        modifier = Modifier.padding(top = 8.dp)
-                    )
-
-                    uiState.formattedDataDate?.let { formattedDate ->
-                        Text(
-                            text = formattedDate,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(top = 4.dp)
-                        )
-                    }
-                }
-
-                IconButton(
-                    onClick = { viewModel.refreshExchangeRates() },
-                    enabled = !uiState.isRefreshing
-                ) {
-                    Icon(
-                        Icons.Default.Refresh,
-                        contentDescription = "새로고침"
-                    )
-                }
-            }
-
-            // Favorites filter toggle
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 8.dp),
-                horizontalArrangement = Arrangement.End,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = "즐겨찾기만 보기",
-                    style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.padding(end = 8.dp)
-                )
-                Switch(
-                    checked = uiState.showFavoritesOnly,
-                    onCheckedChange = { viewModel.toggleFavoritesFilter() }
-                )
-            }
-        }
-
-        when {
-            uiState.isLoading -> {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    CircularProgressIndicator()
-                }
-            }
-
-            uiState.filteredExchangeRates.isEmpty() -> {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = "환율 정보를 불러올 수 없습니다",
-                        style = MaterialTheme.typography.bodyLarge,
-                        textAlign = TextAlign.Center
-                    )
-                }
-            }
-
-            else -> {
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(
-                        start = 16.dp,
-                        end = 16.dp,
-                        top = 8.dp,
-                        bottom = 4.dp
+            // Error handling
+            uiState.errorMessage?.let { error ->
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
                     ),
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
-                    items(uiState.filteredExchangeRates) { exchangeRate ->
-                        SimpleExchangeRateCard(
-                            exchangeRate = exchangeRate,
-                            isFavorite = uiState.favoriteIds.contains(exchangeRate.currencyCode),
-                            onFavoriteClick = { onFavoriteClick(exchangeRate.currencyCode) }
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(
+                            text = "오류",
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.onErrorContainer,
                         )
+                        Text(
+                            text = error,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                            modifier = Modifier.padding(top = 4.dp),
+                        )
+                        Button(
+                            onClick = onClearErrorClick,
+                            modifier = Modifier.padding(top = 8.dp),
+                        ) {
+                            Text("확인")
+                        }
+                    }
+                }
+            }
+
+            // Header with refresh button and favorites toggle
+            Column(
+                modifier = Modifier.padding(horizontal = 16.dp),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column {
+                        Text(
+                            text = "실시간 환율",
+                            style = MaterialTheme.typography.headlineSmall,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.padding(top = 8.dp),
+                        )
+
+                        uiState.formattedDataDate?.let { formattedDate ->
+                            Text(
+                                text = formattedDate,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(top = 4.dp),
+                            )
+                        }
+                    }
+
+                    IconButton(
+                        onClick = onRefreshClick,
+                        enabled = uiState.canRefresh,
+                    ) {
+                        Icon(
+                            Icons.Default.Refresh,
+                            contentDescription = "새로고침",
+                        )
+                    }
+                }
+
+                // Favorites filter toggle
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "즐겨찾기만 보기",
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(end = 8.dp),
+                    )
+                    Switch(
+                        checked = uiState.showFavoritesOnly,
+                        onCheckedChange = { onToggleFavoritesFilter() },
+                    )
+                }
+            }
+
+            when {
+                uiState.isLoading -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        LoadingStatus(message = "환율 정보를 불러오는 중이에요")
+                    }
+                }
+
+                uiState.filteredExchangeRates.isEmpty() -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = "환율 정보를 불러올 수 없습니다",
+                            style = MaterialTheme.typography.bodyLarge,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                }
+
+                else -> {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(
+                            start = 16.dp,
+                            end = 16.dp,
+                            top = 8.dp,
+                            bottom = 4.dp,
+                        ),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        items(uiState.filteredExchangeRates) { exchangeRate ->
+                            SimpleExchangeRateCard(
+                                exchangeRate = exchangeRate,
+                                isFavorite = uiState.favoriteIds.contains(exchangeRate.currencyCode),
+                                onFavoriteClick = {
+                                    onFavoriteClick(exchangeRate.currencyCode)
+                                },
+                            )
+                        }
                     }
                 }
             }
         }
+
+        if (uiState.isRefreshing) {
+            RefreshLoadingOverlay(modifier = Modifier.fillMaxSize())
+        }
+    }
+}
+
+@Composable
+private fun LoadingStatus(
+    message: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        CircularProgressIndicator(modifier = Modifier.size(44.dp))
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(top = 16.dp),
+        )
+    }
+}
+
+@Composable
+private fun RefreshLoadingOverlay(
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.78f))
+            .pointerInput(Unit) {
+                awaitPointerEventScope {
+                    while (true) {
+                        awaitPointerEvent(PointerEventPass.Initial)
+                            .changes
+                            .forEach { it.consume() }
+                    }
+                }
+            }
+            .semantics {
+                liveRegion = LiveRegionMode.Polite
+        },
+        contentAlignment = Alignment.Center,
+    ) {
+        LoadingStatus(
+            message = "최신 환율로 새로고침 중이에요",
+            modifier = Modifier.padding(horizontal = 32.dp),
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/net/ifmain/hwanultoktok/kmp/presentation/viewmodel/AlertViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/net/ifmain/hwanultoktok/kmp/presentation/viewmodel/AlertViewModel.kt
@@ -102,7 +102,7 @@ class AlertViewModel(
     
     fun startBackgroundMonitoring() {
         viewModelScope.launch {
-            scheduleExchangeRateCheckUseCase(15)
+            scheduleExchangeRateCheckUseCase()
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/net/ifmain/hwanultoktok/kmp/presentation/viewmodel/ExchangeRateViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/net/ifmain/hwanultoktok/kmp/presentation/viewmodel/ExchangeRateViewModel.kt
@@ -2,6 +2,8 @@ package net.ifmain.hwanultoktok.kmp.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -20,6 +22,8 @@ import net.ifmain.hwanultoktok.kmp.domain.usecase.ToggleFavoriteUseCase
 import net.ifmain.hwanultoktok.kmp.presentation.state.ExchangeRateUiState
 import net.ifmain.hwanultoktok.kmp.util.formatDateTime
 import net.ifmain.hwanultoktok.kmp.util.getDataBaseDateWithoutHoliday
+
+internal const val REFRESH_COOLDOWN_MILLIS = 5_000L
 
 class ExchangeRateViewModel(
     private val getExchangeRatesUseCase: GetExchangeRatesUseCase,
@@ -87,33 +91,62 @@ class ExchangeRateViewModel(
     }
 
     fun refreshExchangeRates() {
+        if (!_uiState.value.canRefresh) return
+
         println("ExchangeRateViewModel: 새로고침 시작")
+        _uiState.update { currentState ->
+            currentState.copy(
+                isRefreshing = true,
+                isRefreshThrottled = true,
+                errorMessage = null,
+            )
+        }
+
         viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isRefreshing = true)
+            try {
+                val result = refreshExchangeRatesUseCase()
+                result.fold(
+                    onSuccess = { rates ->
+                        println("ExchangeRateViewModel: 새로고침 성공 - ${rates.size}개 환율")
+                        val updateTime = rates.firstOrNull()?.timestamp
 
-            val result = refreshExchangeRatesUseCase()
-            result.fold(
-                onSuccess = { rates ->
-                    println("ExchangeRateViewModel: 새로고침 성공 - ${rates.size}개 환율")
-                    val updateTime = rates.firstOrNull()?.timestamp
+                        _uiState.update { currentState ->
+                            currentState.copy(
+                                exchangeRates = rates,
+                                errorMessage = null,
+                                lastUpdateTime = updateTime,
+                            )
+                        }
 
-                    _uiState.value = _uiState.value.copy(
-                        isRefreshing = false,
-                        exchangeRates = rates,
-                        errorMessage = null,
-                        lastUpdateTime = updateTime
-                    )
-
-                    // 공휴일을 고려한 실제 데이터 기준일 계산
-                    updateTime?.let { updateFormattedDataDate(it) }
-                },
-                onFailure = { error ->
-                    _uiState.value = _uiState.value.copy(
-                        isRefreshing = false,
-                        errorMessage = error.message ?: "새로고침에 실패했습니다"
+                        // 공휴일을 고려한 실제 데이터 기준일 계산
+                        updateTime?.let { updateFormattedDataDate(it) }
+                    },
+                    onFailure = { error ->
+                        _uiState.update { currentState ->
+                            currentState.copy(
+                                errorMessage = error.message ?: "새로고침에 실패했습니다",
+                            )
+                        }
+                    },
+                )
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                _uiState.update { currentState ->
+                    currentState.copy(
+                        errorMessage = error.message ?: "새로고침에 실패했습니다",
                     )
                 }
-            )
+            } finally {
+                _uiState.update { currentState ->
+                    currentState.copy(isRefreshing = false)
+                }
+            }
+
+            delay(REFRESH_COOLDOWN_MILLIS)
+            _uiState.update { currentState ->
+                currentState.copy(isRefreshThrottled = false)
+            }
         }
     }
 

--- a/composeApp/src/commonTest/kotlin/net/ifmain/hwanultoktok/kmp/presentation/viewmodel/ExchangeRateViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/net/ifmain/hwanultoktok/kmp/presentation/viewmodel/ExchangeRateViewModelTest.kt
@@ -1,12 +1,15 @@
 package net.ifmain.hwanultoktok.kmp.presentation.viewmodel
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.datetime.LocalDateTime
@@ -26,6 +29,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ExchangeRateViewModelTest {
@@ -106,10 +110,63 @@ class ExchangeRateViewModelTest {
 
             assertFalse(callbackCalled)
         }
+
+    @Test
+    fun refresh_blocks_duplicate_requests_and_keeps_five_second_cooldown_after_completion() =
+        runTest(mainDispatcher) {
+            val refreshResult = CompletableDeferred<Result<List<ExchangeRate>>>()
+            val exchangeRateRepository = FakeExchangeRateRepository(
+                refreshResultOverride = { refreshResult.await() },
+            )
+            val viewModel = ExchangeRateViewModel(
+                getExchangeRatesUseCase = GetExchangeRatesUseCase(exchangeRateRepository),
+                refreshExchangeRatesUseCase = RefreshExchangeRatesUseCase(exchangeRateRepository),
+                getFavoriteUseCase = GetFavoritesUseCase(FakeFavoriteRepository()),
+                toggleFavoriteUseCase = ToggleFavoriteUseCase(FakeFavoriteRepository()),
+                getHolidaysUseCase = GetHolidaysUseCase(FakeHolidayRepository()),
+            )
+
+            viewModel.refreshExchangeRates()
+            viewModel.refreshExchangeRates()
+
+            assertTrue(viewModel.uiState.value.isRefreshing)
+            assertFalse(viewModel.uiState.value.canRefresh)
+
+            runCurrent()
+            assertEquals(1, exchangeRateRepository.refreshExchangeRatesCallCount)
+
+            refreshResult.complete(Result.success(emptyList()))
+            runCurrent()
+
+            assertFalse(viewModel.uiState.value.isRefreshing)
+            assertTrue(viewModel.uiState.value.isRefreshThrottled)
+            assertFalse(viewModel.uiState.value.canRefresh)
+
+            viewModel.refreshExchangeRates()
+            runCurrent()
+            assertEquals(1, exchangeRateRepository.refreshExchangeRatesCallCount)
+
+            advanceTimeBy(REFRESH_COOLDOWN_MILLIS - 1)
+            runCurrent()
+            assertFalse(viewModel.uiState.value.canRefresh)
+
+            advanceTimeBy(1)
+            runCurrent()
+            assertTrue(viewModel.uiState.value.canRefresh)
+
+            viewModel.refreshExchangeRates()
+            advanceUntilIdle()
+
+            assertEquals(2, exchangeRateRepository.refreshExchangeRatesCallCount)
+        }
 }
 
-private class FakeExchangeRateRepository : ExchangeRateRepository {
+private class FakeExchangeRateRepository(
+    private val refreshResultOverride: (suspend () -> Result<List<ExchangeRate>>)? = null,
+) : ExchangeRateRepository {
     var getExchangeRatesCallCount = 0
+        private set
+    var refreshExchangeRatesCallCount = 0
         private set
 
     private val rates = listOf(
@@ -130,7 +187,10 @@ private class FakeExchangeRateRepository : ExchangeRateRepository {
         return flowOf(rates)
     }
 
-    override suspend fun refreshExchangeRates(): Result<List<ExchangeRate>> = Result.success(rates)
+    override suspend fun refreshExchangeRates(): Result<List<ExchangeRate>> {
+        refreshExchangeRatesCallCount += 1
+        return refreshResultOverride?.invoke() ?: Result.success(rates)
+    }
 
     override suspend fun getPreviousExchangeRates(): List<ExchangeRate> = emptyList()
 


### PR DESCRIPTION
## 변경 사항

### 정시 알림 안정화
- 지연될 수 있는 24시간 주기 WorkManager 예약을 평일 오전 11시 30분(KST) AlarmManager 예약으로 전환
- 정확한 알람 권한이 있으면 `setExactAndAllowWhileIdle`, 없으면 일반 알람으로 대체해 기능 유지
- 부팅·날짜/시간·타임존 변경·앱 업데이트·권한 상태 변경 시 다음 알람 재등록
- 알람 수신 즉시 다음 평일 알람을 예약하고, 일회성 WorkManager 작업으로 환율 조회 및 알림 처리
- 알림 권한 요청 후 정확한 알람 설정 안내를 한 번만 노출

### 새로고침 UX 개선
- 새로고침 시작 시 상태를 즉시 잠가 연속 요청 차단
- 요청 완료 후 5초 동안 새로고침 쿨다운 적용
- 명시적 새로고침 중 화면 입력을 차단하는 반투명 오버레이와 로딩 문구 표시
- 예외 및 코루틴 취소 상황에서도 새로고침 상태가 정상 복구되도록 처리

### 검증 코드 보강
- 평일·주말·목표 시각 전후 알람 계산 단위 테스트 추가
- 알람 등록·취소·복원 실기기 테스트 추가
- 새로고침 중 로딩 상태와 버튼 비활성화 Compose UI 테스트 추가
- 중복 요청 차단 및 5초 쿨다운 ViewModel 테스트 추가

## 문제 원인

- 기존 `PeriodicWorkRequest`는 실행 간격만 보장하고 특정 시각 실행은 보장하지 않아 절전 정책과 시스템 스케줄링에 따라 오전 11시 30분 알림이 지연될 수 있었습니다.
- 기존 새로고침은 요청 실행 중에만 버튼을 막아 응답 직후 다시 연속 호출할 수 있었고, 화면 전체에서 갱신 상태를 명확히 알 수 없었습니다.

## 사용자 영향

- 정확한 알람 권한을 허용한 단말은 평일 오전 11시 30분에 환율 확인 작업이 예약됩니다.
- 권한이 없는 단말도 일반 알람으로 동작하지만 시스템 상황에 따라 지연될 수 있습니다.
- 연속 새로고침으로 인한 중복 네트워크 요청이 방지되고, 갱신 중임을 화면에서 명확히 확인할 수 있습니다.

## 광고 확인 결과

- 하단 배너 광고는 비동기 로딩을 기다린 뒤 정상 노출됨을 확인했습니다.
- 전면 광고는 로드 완료 로그를 확인했습니다.
- 광고 구현 결함은 확인되지 않아 관련 코드는 변경하지 않았습니다.

## 검증

- [x] Debug 단위 테스트 성공
- [x] Debug APK 및 Android 테스트 APK 빌드 성공
- [x] SM-G991N(Android 15)에서 정확한 알람 등록(`window=0`) 확인
- [x] 알람 수신 → WorkManager → API 조회 → 알림 게시 전체 경로 확인
- [x] 실기기에서 새로고침 제한 및 반투명 로딩 오버레이 확인
- [x] 새로고침 Compose UI 테스트 성공
- [x] Lint 오류 0개
- [x] Release AAB 빌드 성공

## 배포 전 남은 확인

- [ ] 새 릴리스 버전 확정 후 versionName/versionCode 증가
