### PR TITLE
🚀Release v1.0.8: 정시 알림 및 새로고침 UX 안정화

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,5 +10,5 @@ plugins {
 }
 
 allprojects {
-    version = "1.0.7"
+    version = "1.0.8"
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -141,8 +141,8 @@ android {
         applicationId = "net.ifmain.hwanultoktok.kmp"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 8
-        versionName = "1.0.7"
+        versionCode = 9
+        versionName = "1.0.8"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         
         // Load API key from local.properties


### PR DESCRIPTION
## 변경 사항

### 정시 알림 안정화
- 평일 오전 11시 30분(KST) AlarmManager 기반 예약 적용
- 정확한 알람 권한 허용 시 정시 예약, 미허용 시 일반 알람 fallback
- 부팅·시간·타임존·앱 업데이트·권한 변경 시 다음 알람 재등록

### 새로고침 UX 개선
- 연속 새로고침 요청 차단 및 완료 후 5초 쿨다운 적용
- 새로고침 중 입력을 막는 반투명 로딩 오버레이와 상태 문구 표시
- 예외·취소 상황에서도 새로고침 상태 복구

### Android 릴리스 대응
- versionName 1.0.8 / versionCode 9 적용
- targetSdk 36 유지
- 서명된 Release APK/AAB 생성

## 검증

- [x] Debug·Release 단위 테스트 각각 22개 성공
- [x] Lint 오류 0개
- [x] Debug APK·Android 테스트 APK·서명된 Release APK/AAB 생성
- [x] SM-G991N(Android 15)에서 v1.0.8/code 9 설치 확인
- [x] 정확한 알람이 평일 오전 11시 30분, window=0으로 등록되는지 확인
- [x] 알람 등록·복원 및 새로고침 UI 계측 테스트 성공
- [x] Android 16/API 36.1에서 Release APK 설치·실행·광고 노출 확인
- [ ] 실기기 정부 API→알림 통합 테스트: 공휴일 API 요청 90초 타임아웃

## 통합 테스트 참고

- 동일 API와 인증키는 개발 Mac에서 HTTP 200으로 정상 응답
- 실기기는 DNS·TCP 443·Wi-Fi VALIDATED 상태이나 계측 테스트 내 요청이 완료되지 않음
- 빌드·서명·화면 실행 검증과는 별개로 단말 네트워크/API 연동 재확인 필요

## 배포 전 남은 확인

- [ ] PR 병합 후 병합된 main 커밋에 annotated tag `v1.0.8` 생성 및 푸시
- [ ] Google Play Production 업로드 및 출시 노트 반영
