### PR TITLE
🚀 Android 환율 로딩 안정성 및 실패 복구 개선

### DIFF
--- a/composeApp/src/androidInstrumentedTest/kotlin/net/ifmain/hwanultoktok/kmp/presentation/ui/ExchangeRateScreenDeviceTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/net/ifmain/hwanultoktok/kmp/presentation/ui/ExchangeRateScreenDeviceTest.kt
@@ -2,17 +2,22 @@ package net.ifmain.hwanultoktok.kmp.presentation.ui
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasProgressBarRangeInfo
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import net.ifmain.hwanultoktok.kmp.presentation.state.ExchangeRateUiState
+import net.ifmain.hwanultoktok.kmp.presentation.viewmodel.EXCHANGE_RATE_LOAD_ERROR_MESSAGE
 import org.junit.Rule
 import org.junit.runner.RunWith
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 @RunWith(AndroidJUnit4::class)
 class ExchangeRateScreenDeviceTest {
@@ -27,6 +32,7 @@ class ExchangeRateScreenDeviceTest {
                 ExchangeRateScreen(
                     uiState = ExchangeRateUiState(isRefreshing = true),
                     onRefreshClick = {},
+                    onRetryClick = {},
                     onClearErrorClick = {},
                     onToggleFavoritesFilter = {},
                     onFavoriteClick = {},
@@ -43,5 +49,42 @@ class ExchangeRateScreenDeviceTest {
         composeTestRule
             .onNodeWithContentDescription("새로고침")
             .assertIsNotEnabled()
+    }
+
+    @Test
+    fun initialLoadErrorShowsRetryActionAndInvokesCallback() {
+        var retryCount = 0
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                ExchangeRateScreen(
+                    uiState = ExchangeRateUiState(
+                        errorMessage = EXCHANGE_RATE_LOAD_ERROR_MESSAGE,
+                    ),
+                    onRefreshClick = {},
+                    onRetryClick = { retryCount += 1 },
+                    onClearErrorClick = {},
+                    onToggleFavoritesFilter = {},
+                    onFavoriteClick = {},
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithText("환율 정보를 불러오지 못했어요")
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(EXCHANGE_RATE_LOAD_ERROR_MESSAGE)
+            .assertIsDisplayed()
+        composeTestRule
+            .onAllNodesWithText("환율 정보를 불러오는 중이에요")
+            .assertCountEquals(0)
+        composeTestRule
+            .onNodeWithText("다시 시도")
+            .performClick()
+
+        composeTestRule.runOnIdle {
+            assertEquals(1, retryCount)
+        }
     }
 }

--- a/composeApp/src/androidInstrumentedTest/kotlin/net/ifmain/hwanultoktok/kmp/worker/ExchangeRateWorkExecutorDeviceTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/net/ifmain/hwanultoktok/kmp/worker/ExchangeRateWorkExecutorDeviceTest.kt
@@ -7,8 +7,10 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import net.ifmain.hwanultoktok.kmp.domain.model.AlertType
 import net.ifmain.hwanultoktok.kmp.domain.model.ExchangeRateAlert
 import net.ifmain.hwanultoktok.kmp.domain.repository.AlertRepository
@@ -66,7 +68,9 @@ class ExchangeRateWorkExecutorDeviceTest {
         val notificationId = testAlert.id.hashCode()
 
         try {
-            executor.execute()
+            withContext(Dispatchers.Default) {
+                executor.execute()
+            }
 
             val firstNotification = notificationManager.activeNotifications
                 .firstOrNull { it.id == notificationId }
@@ -81,7 +85,9 @@ class ExchangeRateWorkExecutorDeviceTest {
                 .single { it.id == testAlert.id }
             assertFalse(persistedAlert.isArmed)
 
-            executor.execute()
+            withContext(Dispatchers.Default) {
+                executor.execute()
+            }
 
             val secondNotification = notificationManager.activeNotifications
                 .firstOrNull { it.id == notificationId }

--- a/composeApp/src/androidMain/kotlin/net/ifmain/hwanultoktok/kmp/di/HttpClientFactory.android.kt
+++ b/composeApp/src/androidMain/kotlin/net/ifmain/hwanultoktok/kmp/di/HttpClientFactory.android.kt
@@ -7,5 +7,10 @@ import net.ifmain.hwanultoktok.kmp.BuildConfig
 actual val isNetworkLoggingEnabled: Boolean = BuildConfig.DEBUG
 
 actual fun createPlatformHttpClient(): HttpClient {
-    return HttpClient(Android)
+    return HttpClient(Android) {
+        engine {
+            connectTimeout = HTTP_CONNECT_TIMEOUT_MILLIS.toInt()
+            socketTimeout = HTTP_SOCKET_TIMEOUT_MILLIS.toInt()
+        }
+    }
 }

--- a/composeApp/src/androidMain/kotlin/net/ifmain/hwanultoktok/kmp/widget/FavoriteExchangeRateWidgetReceiver.kt
+++ b/composeApp/src/androidMain/kotlin/net/ifmain/hwanultoktok/kmp/widget/FavoriteExchangeRateWidgetReceiver.kt
@@ -5,16 +5,13 @@ import android.content.Intent
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.updateAll
-import io.ktor.client.HttpClient
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.serialization.json.Json
 import net.ifmain.hwanultoktok.kmp.BuildConfig
 import net.ifmain.hwanultoktok.kmp.data.mapper.toDomain
 import net.ifmain.hwanultoktok.kmp.data.remote.KoreaExImBankApi
+import net.ifmain.hwanultoktok.kmp.di.createHttpClient
 import net.ifmain.hwanultoktok.kmp.util.getCurrentDateTime
 import net.ifmain.hwanultoktok.kmp.util.getDataBaseDateWithoutHoliday
 
@@ -40,16 +37,8 @@ class FavoriteExchangeRateWidgetReceiver : GlanceAppWidgetReceiver() {
 
     private fun refreshWidgetData(context: Context) {
         CoroutineScope(Dispatchers.IO).launch {
+            val httpClient = createHttpClient()
             try {
-                val httpClient = HttpClient {
-                    install(ContentNegotiation) {
-                        json(Json {
-                            ignoreUnknownKeys = true
-                            coerceInputValues = true
-                        })
-                    }
-                }
-
                 val api = KoreaExImBankApi(httpClient)
                 val apiKey = BuildConfig.KOREAEXIM_API_KEY
 
@@ -66,6 +55,8 @@ class FavoriteExchangeRateWidgetReceiver : GlanceAppWidgetReceiver() {
                 e.printStackTrace()
                 // 실패해도 위젯 UI는 업데이트
                 FavoriteExchangeRateWidget().updateAll(context)
+            } finally {
+                httpClient.close()
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/net/ifmain/hwanultoktok/kmp/data/repository/ExchangeRateRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/net/ifmain/hwanultoktok/kmp/data/repository/ExchangeRateRepositoryImpl.kt
@@ -1,22 +1,28 @@
 package net.ifmain.hwanultoktok.kmp.data.repository
 
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 import net.ifmain.hwanultoktok.kmp.data.mapper.toDomain
 import net.ifmain.hwanultoktok.kmp.data.remote.KoreaExImBankApi
+import net.ifmain.hwanultoktok.kmp.data.remote.dto.ExchangeRateDto
 import net.ifmain.hwanultoktok.kmp.domain.model.ExchangeRate
 import net.ifmain.hwanultoktok.kmp.domain.repository.ExchangeRateRepository
 import net.ifmain.hwanultoktok.kmp.domain.repository.HolidayRepository
 import net.ifmain.hwanultoktok.kmp.domain.usecase.GetHolidaysUseCase
-import net.ifmain.hwanultoktok.kmp.util.getDataBaseDate
+import net.ifmain.hwanultoktok.kmp.util.getDataBaseDateWithFallback
 import net.ifmain.hwanultoktok.kmp.util.getDataBaseDateWithoutHoliday
 import net.ifmain.hwanultoktok.kmp.util.getCurrentDateTime
 
 class ExchangeRateRepositoryImpl(
     private val api: KoreaExImBankApi,
     private val apiKey: String,
-    private val holidayRepository: HolidayRepository
+    private val holidayRepository: HolidayRepository,
+    private val nowProvider: () -> LocalDateTime = ::getCurrentDateTime,
 ) : ExchangeRateRepository {
 
     private var cachedRates: List<ExchangeRate> = emptyList()
@@ -37,24 +43,35 @@ class ExchangeRateRepositoryImpl(
 
     override suspend fun refreshExchangeRates(): Result<List<ExchangeRate>> {
         return try {
-            val now = getCurrentDateTime()
-            
-            // 공휴일을 고려한 정확한 날짜 계산
-            val dataDate = try {
-                getDataBaseDate(now, createGetHolidaysUseCase())
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                // 공휴일 API 실패시 기본 로직으로 fallback
-                println("ExchangeRateRepositoryImpl: 공휴일 API 실패, 기본 로직 사용 - ${e.message}")
-                getDataBaseDateWithoutHoliday(now)
+            val exchangeRates = coroutineScope {
+                val now = nowProvider()
+                val fallbackDate = getDataBaseDateWithoutHoliday(now)
+                val holidayAwareDate = async {
+                    getDataBaseDateWithFallback(now, createGetHolidaysUseCase())
+                }
+
+                var dataDate = fallbackDate
+                var response = getExchangeRateResponse(dataDate)
+
+                if (response.isEmpty()) {
+                    dataDate = holidayAwareDate.await()
+                    if (dataDate != fallbackDate) {
+                        response = getExchangeRateResponse(dataDate)
+                    }
+                } else {
+                    holidayAwareDate.cancel()
+                }
+
+                check(response.isNotEmpty()) {
+                    "조회된 환율 정보가 없습니다."
+                }
+                println(
+                    "ExchangeRateRepositoryImpl: API 응답 받음 - " +
+                        "${response.size}개 데이터 (기준일: $dataDate)",
+                )
+                response.map { it.toDomain() }
             }
-            
-            val searchDate = dataDate.toString().replace("-", "")
-            println("ExchangeRateRepositoryImpl: API 요청 시작 - 날짜: $searchDate (공휴일 고려)")
-            val response = api.getExchangeRates(apiKey, searchDate)
-            println("ExchangeRateRepositoryImpl: API 응답 받음 - ${response.size}개 데이터")
-            val exchangeRates = response.map { it.toDomain() }
+
             cachedRates = exchangeRates
             println("ExchangeRateRepositoryImpl: 데이터 변환 및 캐시 저장 완료")
             Result.success(exchangeRates)
@@ -78,5 +95,16 @@ class ExchangeRateRepositoryImpl(
     // HolidayRepository를 GetHolidaysUseCase로 변환하는 헬퍼 함수
     private fun createGetHolidaysUseCase(): GetHolidaysUseCase {
         return GetHolidaysUseCase(holidayRepository)
+    }
+
+    private suspend fun getExchangeRateResponse(
+        dataDate: LocalDate,
+    ): List<ExchangeRateDto> {
+        val searchDate = dataDate.toString().replace("-", "")
+        println("ExchangeRateRepositoryImpl: API 요청 시작 - 날짜: $searchDate")
+        return api.getExchangeRates(
+            authKey = apiKey,
+            searchDate = searchDate,
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/net/ifmain/hwanultoktok/kmp/di/HttpClientFactory.kt
+++ b/composeApp/src/commonMain/kotlin/net/ifmain/hwanultoktok/kmp/di/HttpClientFactory.kt
@@ -2,6 +2,7 @@ package net.ifmain.hwanultoktok.kmp.di
 
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
@@ -12,13 +13,24 @@ import kotlinx.serialization.json.Json
 expect fun createPlatformHttpClient(): HttpClient
 expect val isNetworkLoggingEnabled: Boolean
 
+internal const val HTTP_CONNECT_TIMEOUT_MILLIS = 10_000L
+internal const val HTTP_REQUEST_TIMEOUT_MILLIS = 15_000L
+internal const val HTTP_SOCKET_TIMEOUT_MILLIS = 15_000L
+
 fun createHttpClient(
     platformClient: HttpClient = createPlatformHttpClient(),
     enableNetworkLogging: Boolean = isNetworkLoggingEnabled,
 ): HttpClient {
     return platformClient.config {
+        install(HttpTimeout) {
+            connectTimeoutMillis = HTTP_CONNECT_TIMEOUT_MILLIS
+            requestTimeoutMillis = HTTP_REQUEST_TIMEOUT_MILLIS
+            socketTimeoutMillis = HTTP_SOCKET_TIMEOUT_MILLIS
+        }
+
         install(ContentNegotiation) {
             json(Json {
+                coerceInputValues = true
                 ignoreUnknownKeys = true
                 isLenient = true
                 prettyPrint = true

--- a/composeApp/src/commonMain/kotlin/net/ifmain/hwanultoktok/kmp/presentation/ui/ExchangeRateScreen.kt
+++ b/composeApp/src/commonMain/kotlin/net/ifmain/hwanultoktok/kmp/presentation/ui/ExchangeRateScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -65,6 +66,7 @@ fun ExchangeRateScreen(
     ExchangeRateScreen(
         uiState = uiState,
         onRefreshClick = viewModel::refreshExchangeRates,
+        onRetryClick = viewModel::retryExchangeRates,
         onClearErrorClick = viewModel::clearError,
         onToggleFavoritesFilter = viewModel::toggleFavoritesFilter,
         onFavoriteClick = onFavoriteClick,
@@ -76,6 +78,7 @@ fun ExchangeRateScreen(
 internal fun ExchangeRateScreen(
     uiState: ExchangeRateUiState,
     onRefreshClick: () -> Unit,
+    onRetryClick: () -> Unit,
     onClearErrorClick: () -> Unit,
     onToggleFavoritesFilter: () -> Unit,
     onFavoriteClick: (String) -> Unit,
@@ -89,36 +92,13 @@ internal fun ExchangeRateScreen(
         Column(
             modifier = Modifier.fillMaxSize(),
         ) {
-            // Error handling
-            uiState.errorMessage?.let { error ->
-                Card(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.errorContainer,
-                    ),
-                ) {
-                    Column(modifier = Modifier.padding(16.dp)) {
-                        Text(
-                            text = "오류",
-                            style = MaterialTheme.typography.titleSmall,
-                            color = MaterialTheme.colorScheme.onErrorContainer,
-                        )
-                        Text(
-                            text = error,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onErrorContainer,
-                            modifier = Modifier.padding(top = 4.dp),
-                        )
-                        Button(
-                            onClick = onClearErrorClick,
-                            modifier = Modifier.padding(top = 8.dp),
-                        ) {
-                            Text("확인")
-                        }
-                    }
-                }
+            if (uiState.errorMessage != null && uiState.exchangeRates.isNotEmpty()) {
+                ExchangeRateErrorCard(
+                    message = uiState.errorMessage,
+                    retryEnabled = uiState.canRefresh,
+                    onRetryClick = onRetryClick,
+                    onDismissClick = onClearErrorClick,
+                )
             }
 
             // Header with refresh button and favorites toggle
@@ -189,17 +169,21 @@ internal fun ExchangeRateScreen(
                     }
                 }
 
-                uiState.filteredExchangeRates.isEmpty() -> {
-                    Box(
+                uiState.errorMessage != null -> {
+                    ExchangeRateErrorContent(
+                        message = uiState.errorMessage,
+                        retryEnabled = uiState.canRefresh,
+                        onRetryClick = onRetryClick,
                         modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Text(
-                            text = "환율 정보를 불러올 수 없습니다",
-                            style = MaterialTheme.typography.bodyLarge,
-                            textAlign = TextAlign.Center,
-                        )
-                    }
+                    )
+                }
+
+                uiState.filteredExchangeRates.isEmpty() -> {
+                    EmptyExchangeRateContent(
+                        retryEnabled = uiState.canRefresh,
+                        onRetryClick = onRetryClick,
+                        modifier = Modifier.fillMaxSize(),
+                    )
                 }
 
                 else -> {
@@ -229,6 +213,116 @@ internal fun ExchangeRateScreen(
 
         if (uiState.isRefreshing) {
             RefreshLoadingOverlay(modifier = Modifier.fillMaxSize())
+        }
+    }
+}
+
+@Composable
+private fun ExchangeRateErrorCard(
+    message: String,
+    retryEnabled: Boolean,
+    onRetryClick: () -> Unit,
+    onDismissClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "환율 정보를 업데이트하지 못했어요",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+            )
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+            Row(
+                modifier = Modifier.padding(top = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Button(
+                    onClick = onRetryClick,
+                    enabled = retryEnabled,
+                ) {
+                    Text("다시 시도")
+                }
+                TextButton(
+                    onClick = onDismissClick,
+                    modifier = Modifier.padding(start = 8.dp),
+                ) {
+                    Text("닫기")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ExchangeRateErrorContent(
+    message: String,
+    retryEnabled: Boolean,
+    onRetryClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.padding(horizontal = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = "환율 정보를 불러오지 못했어요",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+        )
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(top = 8.dp),
+        )
+        Button(
+            onClick = onRetryClick,
+            enabled = retryEnabled,
+            modifier = Modifier.padding(top = 16.dp),
+        ) {
+            Text("다시 시도")
+        }
+    }
+}
+
+@Composable
+private fun EmptyExchangeRateContent(
+    retryEnabled: Boolean,
+    onRetryClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.padding(horizontal = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = "표시할 환율 정보가 없습니다",
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+        )
+        Button(
+            onClick = onRetryClick,
+            enabled = retryEnabled,
+            modifier = Modifier.padding(top = 16.dp),
+        ) {
+            Text("다시 시도")
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/net/ifmain/hwanultoktok/kmp/presentation/viewmodel/ExchangeRateViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/net/ifmain/hwanultoktok/kmp/presentation/viewmodel/ExchangeRateViewModel.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
@@ -24,6 +23,10 @@ import net.ifmain.hwanultoktok.kmp.util.formatDateTime
 import net.ifmain.hwanultoktok.kmp.util.getDataBaseDateWithoutHoliday
 
 internal const val REFRESH_COOLDOWN_MILLIS = 5_000L
+internal const val EXCHANGE_RATE_LOAD_ERROR_MESSAGE =
+    "환율 정보를 불러오지 못했습니다. 네트워크 연결을 확인한 뒤 다시 시도해주세요."
+internal const val EXCHANGE_RATE_REFRESH_ERROR_MESSAGE =
+    "최신 환율로 새로고침하지 못했습니다. 잠시 후 다시 시도해주세요."
 
 class ExchangeRateViewModel(
     private val getExchangeRatesUseCase: GetExchangeRatesUseCase,
@@ -55,37 +58,47 @@ class ExchangeRateViewModel(
     }
 
     fun loadExchangeRates() {
+        if (_uiState.value.isLoading || _uiState.value.isRefreshing) return
+
         println("ExchangeRateViewModel: loadExchangeRates 호출")
+        _uiState.update { currentState ->
+            currentState.copy(isLoading = true, errorMessage = null)
+        }
+
         viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = null)
-
             try {
-                getExchangeRatesUseCase()
-                    .catch { error ->
-                        _uiState.value = _uiState.value.copy(
-                            isLoading = false,
-                            errorMessage = error.message ?: "알 수 없는 오류가 발생했습니다"
-                        )
-                    }
-                    .collect { rates ->
-                        println("ExchangeRateViewModel: 데이터 수신 - ${rates.size}개 환율")
-                        val updateTime = rates.firstOrNull()?.timestamp
+                var hasEmittedRates = false
+                getExchangeRatesUseCase().collect { rates ->
+                    hasEmittedRates = true
 
-                        _uiState.value = _uiState.value.copy(
+                    if (rates.isEmpty()) {
+                        showLoadFailure()
+                        return@collect
+                    }
+
+                    println("ExchangeRateViewModel: 데이터 수신 - ${rates.size}개 환율")
+                    val updateTime = rates.first().timestamp
+
+                    _uiState.update { currentState ->
+                        currentState.copy(
                             isLoading = false,
                             exchangeRates = rates,
                             errorMessage = null,
-                            lastUpdateTime = updateTime
+                            lastUpdateTime = updateTime,
                         )
-
-                        // 공휴일을 고려한 실제 데이터 기준일 계산
-                        updateTime?.let { updateFormattedDataDate(it) }
                     }
-            } catch (e: Exception) {
-                _uiState.value = _uiState.value.copy(
-                    isLoading = false,
-                    errorMessage = e.message ?: "알 수 없는 오류가 발생했습니다"
-                )
+
+                    // 공휴일을 고려한 실제 데이터 기준일 계산
+                    updateFormattedDataDate(updateTime)
+                }
+
+                if (!hasEmittedRates) {
+                    showLoadFailure()
+                }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Exception) {
+                showLoadFailure()
             }
         }
     }
@@ -107,8 +120,17 @@ class ExchangeRateViewModel(
                 val result = refreshExchangeRatesUseCase()
                 result.fold(
                     onSuccess = { rates ->
+                        if (rates.isEmpty()) {
+                            _uiState.update { currentState ->
+                                currentState.copy(
+                                    errorMessage = EXCHANGE_RATE_REFRESH_ERROR_MESSAGE,
+                                )
+                            }
+                            return@fold
+                        }
+
                         println("ExchangeRateViewModel: 새로고침 성공 - ${rates.size}개 환율")
-                        val updateTime = rates.firstOrNull()?.timestamp
+                        val updateTime = rates.first().timestamp
 
                         _uiState.update { currentState ->
                             currentState.copy(
@@ -119,22 +141,22 @@ class ExchangeRateViewModel(
                         }
 
                         // 공휴일을 고려한 실제 데이터 기준일 계산
-                        updateTime?.let { updateFormattedDataDate(it) }
+                        updateFormattedDataDate(updateTime)
                     },
-                    onFailure = { error ->
+                    onFailure = {
                         _uiState.update { currentState ->
                             currentState.copy(
-                                errorMessage = error.message ?: "새로고침에 실패했습니다",
+                                errorMessage = EXCHANGE_RATE_REFRESH_ERROR_MESSAGE,
                             )
                         }
                     },
                 )
             } catch (error: CancellationException) {
                 throw error
-            } catch (error: Exception) {
+            } catch (_: Exception) {
                 _uiState.update { currentState ->
                     currentState.copy(
-                        errorMessage = error.message ?: "새로고침에 실패했습니다",
+                        errorMessage = EXCHANGE_RATE_REFRESH_ERROR_MESSAGE,
                     )
                 }
             } finally {
@@ -147,6 +169,19 @@ class ExchangeRateViewModel(
             _uiState.update { currentState ->
                 currentState.copy(isRefreshThrottled = false)
             }
+        }
+    }
+
+    fun retryExchangeRates() {
+        val currentState = _uiState.value
+        if (currentState.isLoading || currentState.isRefreshing || currentState.isRefreshThrottled) {
+            return
+        }
+
+        if (currentState.exchangeRates.isEmpty()) {
+            loadExchangeRates()
+        } else {
+            refreshExchangeRates()
         }
     }
 
@@ -189,7 +224,9 @@ class ExchangeRateViewModel(
                 _uiState.update { currentState ->
                     currentState.copy(formattedDataDate = formattedDate)
                 }
-            } catch (e: Exception) {
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Exception) {
                 // 공휴일 데이터 로드 실패시 기본 포맷 사용 (공휴일 체크 없이)
                 val dataDate = getDataBaseDateWithoutHoliday(updateTime)
                 val basicFormat =
@@ -202,6 +239,17 @@ class ExchangeRateViewModel(
     }
 
     fun clearError() {
-        _uiState.value = _uiState.value.copy(errorMessage = null)
+        _uiState.update { currentState ->
+            currentState.copy(errorMessage = null)
+        }
+    }
+
+    private fun showLoadFailure() {
+        _uiState.update { currentState ->
+            currentState.copy(
+                isLoading = false,
+                errorMessage = EXCHANGE_RATE_LOAD_ERROR_MESSAGE,
+            )
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/net/ifmain/hwanultoktok/kmp/util/DateTimeUtils.kt
+++ b/composeApp/src/commonMain/kotlin/net/ifmain/hwanultoktok/kmp/util/DateTimeUtils.kt
@@ -1,5 +1,7 @@
 package net.ifmain.hwanultoktok.kmp.util
 
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
@@ -11,6 +13,8 @@ import kotlinx.datetime.toLocalDateTime
 import net.ifmain.hwanultoktok.kmp.domain.usecase.GetHolidaysUseCase
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
+
+internal const val HOLIDAY_LOOKUP_TIMEOUT_MILLIS = 5_000L
 
 @OptIn(ExperimentalTime::class)
 fun getCurrentDateTime(): LocalDateTime {
@@ -24,7 +28,7 @@ suspend fun getExchangeRateSearchDate(getHolidaysUseCase: GetHolidaysUseCase): S
     val now = Clock.System.now()
     val koreaTimeZone = TimeZone.of("Asia/Seoul")
     val koreaTime = now.toLocalDateTime(koreaTimeZone)
-    val searchDate = getDataBaseDate(koreaTime, getHolidaysUseCase)
+    val searchDate = getDataBaseDateWithFallback(koreaTime, getHolidaysUseCase)
 
     return searchDate.toString().replace("-", "")
 }
@@ -34,8 +38,24 @@ suspend fun formatDateTime(
     dateTime: LocalDateTime,
     getHolidaysUseCase: GetHolidaysUseCase
 ): String {
-    val dataDate = getDataBaseDate(dateTime, getHolidaysUseCase)
+    val dataDate = getDataBaseDateWithFallback(dateTime, getHolidaysUseCase)
     return "${dataDate.year}년 ${dataDate.month.number}월 ${dataDate.day}일 고시환율"
+}
+
+internal suspend fun getDataBaseDateWithFallback(
+    updateTime: LocalDateTime,
+    getHolidaysUseCase: GetHolidaysUseCase,
+    timeoutMillis: Long = HOLIDAY_LOOKUP_TIMEOUT_MILLIS,
+): LocalDate {
+    return try {
+        withTimeoutOrNull(timeoutMillis) {
+            getDataBaseDate(updateTime, getHolidaysUseCase)
+        } ?: getDataBaseDateWithoutHoliday(updateTime)
+    } catch (error: CancellationException) {
+        throw error
+    } catch (_: Exception) {
+        getDataBaseDateWithoutHoliday(updateTime)
+    }
 }
 
 // 공휴일 체크 없는 기존 로직

--- a/composeApp/src/commonTest/kotlin/net/ifmain/hwanultoktok/kmp/data/repository/ExchangeRateRepositoryImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/net/ifmain/hwanultoktok/kmp/data/repository/ExchangeRateRepositoryImplTest.kt
@@ -2,15 +2,25 @@ package net.ifmain.hwanultoktok.kmp.data.repository
 
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.headersOf
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.LocalDateTime
 import net.ifmain.hwanultoktok.kmp.data.remote.KoreaExImBankApi
+import net.ifmain.hwanultoktok.kmp.di.createHttpClient
 import net.ifmain.hwanultoktok.kmp.domain.model.HolidayItem
 import net.ifmain.hwanultoktok.kmp.domain.repository.HolidayRepository
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ExchangeRateRepositoryImplTest {
     @Test
     fun getExchangeRates_propagates_refresh_failure() = runTest {
@@ -36,9 +46,145 @@ class ExchangeRateRepositoryImplTest {
             client.close()
         }
     }
+
+    @Test
+    fun refresh_does_not_wait_for_holiday_lookup_when_weekday_response_has_rates() = runTest {
+        val client = jsonClient(VALID_EXCHANGE_RATE_RESPONSE)
+
+        try {
+            val repository = ExchangeRateRepositoryImpl(
+                api = KoreaExImBankApi(client),
+                apiKey = "test-api-key",
+                holidayRepository = HangingHolidayRepository,
+            )
+
+            val result = repository.refreshExchangeRates()
+
+            assertTrue(result.isSuccess)
+            assertEquals(1, result.getOrThrow().size)
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun refresh_retries_holiday_adjusted_date_when_weekday_response_is_empty() = runTest {
+        val requestedDates = mutableListOf<String>()
+        val client = createHttpClient(
+            platformClient = HttpClient(
+                MockEngine { request ->
+                    val searchDate = request.url.parameters["searchdate"].orEmpty()
+                    requestedDates += searchDate
+                    respond(
+                        content = if (searchDate == "20260717") {
+                            "[]"
+                        } else {
+                            VALID_EXCHANGE_RATE_RESPONSE
+                        },
+                        headers = JSON_HEADERS,
+                    )
+                },
+            ),
+            enableNetworkLogging = false,
+        )
+
+        try {
+            val repository = ExchangeRateRepositoryImpl(
+                api = KoreaExImBankApi(client),
+                apiKey = "test-api-key",
+                holidayRepository = July17HolidayRepository,
+                nowProvider = { LocalDateTime(2026, 7, 17, 12, 0) },
+            )
+
+            val result = repository.refreshExchangeRates()
+
+            assertTrue(result.isSuccess)
+            assertEquals(listOf("20260717", "20260716"), requestedDates)
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun refresh_treats_empty_api_response_as_failure() = runTest {
+        val client = jsonClient("[]")
+
+        try {
+            val repository = ExchangeRateRepositoryImpl(
+                api = KoreaExImBankApi(client),
+                apiKey = "test-api-key",
+                holidayRepository = SuccessfulHolidayRepository,
+            )
+
+            val result = repository.refreshExchangeRates()
+
+            assertTrue(result.isFailure)
+            assertEquals(
+                "조회된 환율 정보가 없습니다.",
+                result.exceptionOrNull()?.message,
+            )
+        } finally {
+            client.close()
+        }
+    }
 }
 
 private object SuccessfulHolidayRepository : HolidayRepository {
     override suspend fun getHolidays(year: Int, month: Int): Result<List<HolidayItem>> =
         Result.success(emptyList())
 }
+
+private object HangingHolidayRepository : HolidayRepository {
+    override suspend fun getHolidays(
+        year: Int,
+        month: Int,
+    ): Result<List<HolidayItem>> = awaitCancellation()
+}
+
+private object July17HolidayRepository : HolidayRepository {
+    override suspend fun getHolidays(
+        year: Int,
+        month: Int,
+    ): Result<List<HolidayItem>> = Result.success(
+        listOf(
+            HolidayItem(
+                dateKind = "01",
+                dateName = "제헌절",
+                isHoliday = "Y",
+                locdate = 20260717,
+                seq = 1,
+            ),
+        ),
+    )
+}
+
+private fun jsonClient(responseBody: String): HttpClient = createHttpClient(
+    platformClient = HttpClient(
+        MockEngine {
+            respond(
+                content = responseBody,
+                headers = JSON_HEADERS,
+            )
+        },
+    ),
+    enableNetworkLogging = false,
+)
+
+private val JSON_HEADERS = headersOf(
+    HttpHeaders.ContentType,
+    ContentType.Application.Json.toString(),
+)
+
+private const val VALID_EXCHANGE_RATE_RESPONSE = """
+[
+  {
+    "result": 1,
+    "cur_unit": "USD",
+    "cur_nm": "미국 달러",
+    "ttb": "1300.00",
+    "tts": "1400.00",
+    "deal_bas_r": "1350.00",
+    "bkpr": "1350.00"
+  }
+]
+"""

--- a/composeApp/src/commonTest/kotlin/net/ifmain/hwanultoktok/kmp/di/HttpClientFactoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/net/ifmain/hwanultoktok/kmp/di/HttpClientFactoryTest.kt
@@ -3,6 +3,7 @@ package net.ifmain.hwanultoktok.kmp.di
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respondOk
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.plugins.pluginOrNull
 import kotlin.test.Test
@@ -10,6 +11,20 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 class HttpClientFactoryTest {
+    @Test
+    fun timeout_plugin_is_always_installed() {
+        val client = createHttpClient(
+            platformClient = HttpClient(MockEngine { respondOk() }),
+            enableNetworkLogging = false,
+        )
+
+        try {
+            assertNotNull(client.pluginOrNull(HttpTimeout))
+        } finally {
+            client.close()
+        }
+    }
+
     @Test
     fun logging_plugin_is_not_installed_when_network_logging_is_disabled() {
         val client = createHttpClient(

--- a/composeApp/src/commonTest/kotlin/net/ifmain/hwanultoktok/kmp/presentation/viewmodel/ExchangeRateViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/net/ifmain/hwanultoktok/kmp/presentation/viewmodel/ExchangeRateViewModelTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
@@ -29,6 +30,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -65,6 +67,85 @@ class ExchangeRateViewModelTest {
         assertEquals(1, exchangeRateRepository.getExchangeRatesCallCount)
         assertEquals(1, favoriteRepository.getAllFavoritesCallCount)
     }
+
+    @Test
+    fun initial_load_failure_stops_loading_and_shows_retryable_message() =
+        runTest(mainDispatcher) {
+            val exchangeRateRepository = FakeExchangeRateRepository(
+                loadFlowOverride = {
+                    flow {
+                        throw IllegalStateException("network unavailable")
+                    }
+                },
+            )
+            val viewModel = createViewModel(exchangeRateRepository)
+
+            viewModel.loadExchangeRates()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.value.isLoading)
+            assertTrue(viewModel.uiState.value.exchangeRates.isEmpty())
+            assertEquals(
+                EXCHANGE_RATE_LOAD_ERROR_MESSAGE,
+                viewModel.uiState.value.errorMessage,
+            )
+            assertTrue(viewModel.uiState.value.canRefresh)
+        }
+
+    @Test
+    fun load_blocks_duplicate_requests_while_initial_request_is_running() =
+        runTest(mainDispatcher) {
+            val loadGate = CompletableDeferred<Unit>()
+            val exchangeRateRepository = FakeExchangeRateRepository(
+                loadFlowOverride = {
+                    flow {
+                        loadGate.await()
+                        emit(sampleExchangeRates())
+                    }
+                },
+            )
+            val viewModel = createViewModel(exchangeRateRepository)
+
+            viewModel.loadExchangeRates()
+            viewModel.loadExchangeRates()
+            runCurrent()
+
+            assertEquals(1, exchangeRateRepository.getExchangeRatesCallCount)
+
+            loadGate.complete(Unit)
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.value.isLoading)
+        }
+
+    @Test
+    fun retry_after_initial_load_failure_requests_rates_again_and_recovers() =
+        runTest(mainDispatcher) {
+            var loadAttempt = 0
+            val exchangeRateRepository = FakeExchangeRateRepository(
+                loadFlowOverride = {
+                    loadAttempt += 1
+                    if (loadAttempt == 1) {
+                        flow {
+                            throw IllegalStateException("network unavailable")
+                        }
+                    } else {
+                        flowOf(sampleExchangeRates())
+                    }
+                },
+            )
+            val viewModel = createViewModel(exchangeRateRepository)
+
+            viewModel.loadExchangeRates()
+            advanceUntilIdle()
+            viewModel.retryExchangeRates()
+            advanceUntilIdle()
+
+            assertEquals(2, exchangeRateRepository.getExchangeRatesCallCount)
+            assertFalse(viewModel.uiState.value.isLoading)
+            assertEquals(sampleExchangeRates(), viewModel.uiState.value.exchangeRates)
+            assertNull(viewModel.uiState.value.errorMessage)
+        }
 
     @Test
     fun toggle_favorite_invokes_success_callback_after_repository_update() = runTest(mainDispatcher) {
@@ -159,32 +240,35 @@ class ExchangeRateViewModelTest {
 
             assertEquals(2, exchangeRateRepository.refreshExchangeRatesCallCount)
         }
+
+    private fun createViewModel(
+        exchangeRateRepository: ExchangeRateRepository,
+    ): ExchangeRateViewModel {
+        val favoriteRepository = FakeFavoriteRepository()
+        return ExchangeRateViewModel(
+            getExchangeRatesUseCase = GetExchangeRatesUseCase(exchangeRateRepository),
+            refreshExchangeRatesUseCase = RefreshExchangeRatesUseCase(exchangeRateRepository),
+            getFavoriteUseCase = GetFavoritesUseCase(favoriteRepository),
+            toggleFavoriteUseCase = ToggleFavoriteUseCase(favoriteRepository),
+            getHolidaysUseCase = GetHolidaysUseCase(FakeHolidayRepository()),
+        )
+    }
 }
 
 private class FakeExchangeRateRepository(
     private val refreshResultOverride: (suspend () -> Result<List<ExchangeRate>>)? = null,
+    private val loadFlowOverride: (suspend () -> Flow<List<ExchangeRate>>)? = null,
 ) : ExchangeRateRepository {
     var getExchangeRatesCallCount = 0
         private set
     var refreshExchangeRatesCallCount = 0
         private set
 
-    private val rates = listOf(
-        ExchangeRate(
-            currencyCode = "USD",
-            currencyName = "미국 달러",
-            currencyUnit = "USD",
-            buyingRate = 1_300.0,
-            sellingRate = 1_400.0,
-            baseRate = 1_350.0,
-            bookPrice = 1_350.0,
-            timestamp = LocalDateTime(2026, 7, 20, 12, 0),
-        )
-    )
+    private val rates = sampleExchangeRates()
 
     override suspend fun getExchangeRates(): Flow<List<ExchangeRate>> {
         getExchangeRatesCallCount += 1
-        return flowOf(rates)
+        return loadFlowOverride?.invoke() ?: flowOf(rates)
     }
 
     override suspend fun refreshExchangeRates(): Result<List<ExchangeRate>> {
@@ -232,3 +316,16 @@ private class FakeHolidayRepository : HolidayRepository {
     override suspend fun getHolidays(year: Int, month: Int): Result<List<HolidayItem>> =
         Result.success(emptyList())
 }
+
+private fun sampleExchangeRates(): List<ExchangeRate> = listOf(
+    ExchangeRate(
+        currencyCode = "USD",
+        currencyName = "미국 달러",
+        currencyUnit = "USD",
+        buyingRate = 1_300.0,
+        sellingRate = 1_400.0,
+        baseRate = 1_350.0,
+        bookPrice = 1_350.0,
+        timestamp = LocalDateTime(2026, 7, 20, 12, 0),
+    ),
+)

--- a/composeApp/src/commonTest/kotlin/net/ifmain/hwanultoktok/kmp/util/DateTimeUtilsTest.kt
+++ b/composeApp/src/commonTest/kotlin/net/ifmain/hwanultoktok/kmp/util/DateTimeUtilsTest.kt
@@ -1,0 +1,60 @@
+package net.ifmain.hwanultoktok.kmp.util
+
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import net.ifmain.hwanultoktok.kmp.domain.model.HolidayItem
+import net.ifmain.hwanultoktok.kmp.domain.repository.HolidayRepository
+import net.ifmain.hwanultoktok.kmp.domain.usecase.GetHolidaysUseCase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DateTimeUtilsTest {
+    @Test
+    fun holiday_lookup_timeout_falls_back_to_weekday_calculation() = runTest {
+        val updateTime = LocalDateTime(2026, 7, 27, 12, 0)
+        val startTime = testScheduler.currentTime
+
+        val dataDate = getDataBaseDateWithFallback(
+            updateTime = updateTime,
+            getHolidaysUseCase = GetHolidaysUseCase(HangingHolidayRepository),
+        )
+
+        assertEquals(LocalDate(2026, 7, 27), dataDate)
+        assertEquals(
+            HOLIDAY_LOOKUP_TIMEOUT_MILLIS,
+            testScheduler.currentTime - startTime,
+        )
+    }
+
+    @Test
+    fun caller_timeout_is_not_swallowed_by_holiday_fallback() = runTest {
+        var callerTimedOut = false
+
+        try {
+            withTimeout(1_000L) {
+                getDataBaseDateWithFallback(
+                    updateTime = LocalDateTime(2026, 7, 27, 12, 0),
+                    getHolidaysUseCase = GetHolidaysUseCase(HangingHolidayRepository),
+                )
+            }
+        } catch (_: TimeoutCancellationException) {
+            callerTimedOut = true
+        }
+
+        assertTrue(callerTimedOut)
+    }
+}
+
+private object HangingHolidayRepository : HolidayRepository {
+    override suspend fun getHolidays(
+        year: Int,
+        month: Int,
+    ): Result<List<HolidayItem>> = awaitCancellation()
+}


### PR DESCRIPTION
## 변경 사항

### 네트워크 지연 제한
- 연결 타임아웃 10초, 요청·소켓 타임아웃 15초 적용
- 공휴일 조회를 최대 5초로 제한하고 실패 시 평일 기준일 계산으로 대체
- 공휴일 조회와 환율 조회를 병렬 처리해 정상 응답을 기다리는 시간 단축
- 위젯도 앱과 동일한 HTTP 클라이언트와 타임아웃 정책 사용

### 로딩 실패 복구 UX
- 최초 조회가 실패하거나 빈 결과를 반환하면 로딩 상태를 반드시 종료
- 사용자용 오류 문구와 `다시 시도` 동작 제공
- 기존 환율이 있는 상태의 새로고침 실패는 데이터를 유지한 채 오류 카드로 안내
- 중복 최초 조회와 새로고침 중 재시도 차단

### 검증 코드 보강
- HTTP 타임아웃 플러그인 설치 테스트 추가
- 공휴일 API 타임아웃·호출자 취소 전파 테스트 추가
- 공휴일 보정 날짜 재조회 및 빈 응답 실패 테스트 추가
- 최초 로딩 실패·중복 호출·재시도 복구 ViewModel 테스트 추가
- 오류 화면과 재시도 동작 Compose UI 테스트 추가

## 문제 원인

- 연결 단말에 도달할 수 없는 전역 프록시가 남아 있었고, Ktor Android 엔진의 기본 연결·소켓 타임아웃이 각각 100초였습니다.
- 공휴일 API와 환율 API를 순차 호출해 최초 화면이 약 201초 동안 로딩 상태로 유지됐습니다.
- 조회 실패 또는 미방출 Flow에서 로딩을 종료하고 복구할 명시적 경로가 부족했습니다.

## 사용자 영향

- 정상 네트워크에서 최초 23개 환율 표시 시간이 실기기 기준 약 0.37초로 단축됩니다.
- 비정상 프록시·네트워크 장애에서도 무한 로딩하지 않고 제한 시간 후 오류와 재시도 버튼을 표시합니다.
- 공휴일 API가 지연돼도 환율 데이터가 있으면 화면에 먼저 표시됩니다.

## 검증

- [x] Debug 단위 테스트 31개 성공
- [x] Release 단위 테스트 31개 성공
- [x] SM-G991N(Android 15) 계측 테스트 4개 성공
- [x] 정상 네트워크 최초 조회 약 0.37초 확인
- [x] 비정상 프록시 재현 환경 약 10.18초 이내 처리 확인
- [x] Lint 오류 0개
- [x] 서명된 Release APK/AAB 생성 및 서명 검증

## 배포 전 남은 확인

- [ ] 기능 PR 병합 후 v1.0.9 / versionCode 10 릴리스 브랜치 준비
- [ ] 릴리스 PR 병합 후 main 병합 커밋에 annotated tag `v1.0.9` 생성 및 푸시
- [ ] Google Play Production 업로드 및 출시 노트 반영