### PR TITLE
🚀Release v1.0.9: 환율 로딩 안정성 및 실패 복구 개선

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,5 +10,5 @@ plugins {
 }
 
 allprojects {
-    version = "1.0.8"
+    version = "1.0.9"
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -141,8 +141,8 @@ android {
         applicationId = "net.ifmain.hwanultoktok.kmp"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 9
-        versionName = "1.0.8"
+        versionCode = 10
+        versionName = "1.0.9"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         
         // Load API key from local.properties


### PR DESCRIPTION
## 변경 사항

### 환율 로딩 안정화
- 연결 타임아웃 10초, 요청·소켓 타임아웃 15초 적용
- 공휴일 API 조회를 최대 5초로 제한하고 실패 시 안전한 기준일로 대체
- 공휴일 조회와 환율 조회를 병렬화해 정상 네트워크 최초 로딩 단축
- 앱과 위젯의 HTTP 클라이언트·타임아웃 정책 통합

### 실패 복구 UX
- 네트워크 실패·빈 응답·미방출 상황에서 로딩 상태 종료 보장
- 최초 조회 오류 화면과 `다시 시도` 동작 추가
- 새로고침 실패 시 기존 환율을 유지하며 오류 카드 표시
- 중복 요청 및 처리 중 재시도 차단

### Android 릴리스 대응
- versionName 1.0.9 / versionCode 10 적용
- 프로젝트 버전을 1.0.9로 동기화해 산출물 파일명 일치
- targetSdk 36 유지
- 서명된 Release APK/AAB 생성

## 검증

- [x] Debug 단위 테스트 31개 성공
- [x] Release 단위 테스트 31개 성공
- [x] Lint 오류 0개
- [x] SM-G991N(Android 15) 계측 테스트 4개 성공
- [x] 정상 네트워크에서 23개 환율 약 0.37초 내 표시
- [x] 비정상 프록시 환경에서도 무한 로딩 없이 약 10.18초 이내 처리
- [x] v1.0.9/code 10 Release APK 메타데이터 확인
- [x] 서명된 Release APK/AAB 및 AAB 서명 검증

## 배포 전 남은 확인

- [ ] PR 병합 후 병합된 main 커밋에 annotated tag `v1.0.9` 생성 및 푸시
- [ ] Google Play Production에 `hwanultoktok_1.0.9-release.aab` 업로드
- [ ] Google Play 출시 노트 반영