### PR TITLE
🚀 Android 설치 앱 이름 한국어 적용

### DIFF
--- a/composeApp/src/androidMain/res/values/strings.xml
+++ b/composeApp/src/androidMain/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">HwanulTokTok</string>
+    <string name="app_name">환율 톡톡</string>
 </resources>


### PR DESCRIPTION
## 변경 사항

### 설치 앱 이름 변경
- Android 기본 애플리케이션 라벨을 `HwanulTokTok`에서 `환율 톡톡`으로 변경
- 홈 화면·앱 서랍·시스템 앱 정보에서 한국어 앱 이름 사용
- versionName 1.0.9 / versionCode 10 유지

## 변경 이유

- 기존 `app_name` 리소스가 영어로 설정되어 한국어 단말에서도 설치 앱 이름이 `HwanulTokTok`으로 표시됐습니다.
- 앱 내부에서 사용하는 서비스명 `환율 톡톡`과 설치 앱 이름을 일치시킵니다.

## 검증

- [x] Debug 단위 테스트 31개 성공
- [x] Release 단위 테스트 31개 성공
- [x] Lint 오류 0개
- [x] Debug·Release APK의 `application-label`이 `환율 톡톡`인지 확인
- [x] 서명된 Release APK/AAB 생성 성공
- [x] SM-G991N(Android 15)에 v1.0.9/code 10 Debug APK 업데이트 설치 성공

## 병합 후 작업

- [ ] 기존 원격 annotated tag `v1.0.9` 삭제
- [ ] 이 PR의 main 병합 커밋에 `v1.0.9` 태그 재생성 및 푸시
- [ ] 새 태그 기준 AAB 강제 재빌드 및 서명 검증